### PR TITLE
Fixing some namespace issues that could cause backwards compatibility…

### DIFF
--- a/Sion.Useful.Tests/DateTimeMethods.cs
+++ b/Sion.Useful.Tests/DateTimeMethods.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Tests {
 	[TestClass]
@@ -13,7 +9,7 @@ namespace Sion.Useful.Tests {
 			try {
 				DateTime date = Convert.ToDateTime("2000-01-01T00:00:00.000Z").ToUniversalTime();
 				long actual = 946684800000;
-				long result = Methods.DateTimeMethods.ConvertToUnixMilliseconds(date);
+				long result = Sion.Useful.DateTimeMethods.ConvertToUnixMilliseconds(date);
 				Assert.AreEqual(actual, result);
 			}
 			catch(Exception e) {
@@ -26,7 +22,7 @@ namespace Sion.Useful.Tests {
 			try {
 				DateTime date = Convert.ToDateTime("2000-01-01T00:00:00.000Z").ToUniversalTime();
 				long actual = 946684800;
-				long result = Methods.DateTimeMethods.ConvertToUnixSeconds(date);
+				long result = Sion.Useful.DateTimeMethods.ConvertToUnixSeconds(date);
 				Assert.AreEqual(actual, result);
 			}
 			catch(Exception e) {

--- a/Sion.Useful.Tests/DecimalMethods.cs
+++ b/Sion.Useful.Tests/DecimalMethods.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Tests {
 	[TestClass]
@@ -12,7 +8,7 @@ namespace Sion.Useful.Tests {
 		public void Test_Truncate() {
 			try {
 				decimal d = 10.9812M;
-				decimal trunc = Methods.DecimalMethods.Truncate(d, 2);
+				decimal trunc = Sion.Useful.DecimalMethods.Truncate(d, 2);
 				Assert.AreEqual(trunc, 10.98M);
 			}
 			catch(Exception e) {

--- a/Sion.Useful.Tests/DirectedGraph.cs
+++ b/Sion.Useful.Tests/DirectedGraph.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Tests {
 	[TestClass]

--- a/Sion.Useful.Tests/Graph.cs
+++ b/Sion.Useful.Tests/Graph.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Tests {
 	[TestClass]
@@ -130,7 +128,7 @@ namespace Sion.Useful.Tests {
 				List<Classes.Node<int>> expected = new() { node1, node2, node3, node4 };
 				Assert.IsTrue(Enumerable.SequenceEqual(dfs, expected));
 			}
-			catch(Exception e) { 
+			catch(Exception e) {
 				Assert.Fail(e.Message);
 			}
 		}
@@ -180,7 +178,7 @@ namespace Sion.Useful.Tests {
 				List<Classes.Node<int>> expected = new() { node2, node1, node3, node4 };
 				Assert.IsTrue(Enumerable.SequenceEqual(dfs, expected));
 			}
-			catch(Exception e) { 
+			catch(Exception e) {
 				Assert.Fail(e.Message);
 			}
 		}

--- a/Sion.Useful.Tests/WeightedDirectedGraph.cs
+++ b/Sion.Useful.Tests/WeightedDirectedGraph.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Tests {
 	[TestClass]

--- a/Sion.Useful.Tests/WeightedGraph.cs
+++ b/Sion.Useful.Tests/WeightedGraph.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Tests {
 	[TestClass]
@@ -17,7 +15,7 @@ namespace Sion.Useful.Tests {
 				graph.AddNodes(node1, node2);
 				graph.AddEdge(node1, node2, 3);
 				bool wasSuccessful = (
-					node1.Neighbors.Contains(node2) && node1.Weights.Count > 0 
+					node1.Neighbors.Contains(node2) && node1.Weights.Count > 0
 					&& node2.Neighbors.Contains(node1) && node2.Weights.Count > 0
 				);
 				Assert.IsTrue(wasSuccessful);
@@ -129,7 +127,7 @@ namespace Sion.Useful.Tests {
 				graph.AddEdge(node1, node2, 7);
 				graph.RemoveEdge(node1, node2);
 				bool wasSuccessful = (
-					!node1.Neighbors.Contains(node2) && node1.Weights.Count == 0 
+					!node1.Neighbors.Contains(node2) && node1.Weights.Count == 0
 					&& !node2.Neighbors.Contains(node1) && node2.Weights.Count == 0
 				);
 				Assert.IsTrue(wasSuccessful);

--- a/Sion.Useful/Classes/DirectedGraph.cs
+++ b/Sion.Useful/Classes/DirectedGraph.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Classes {
 	public class DirectedGraph<T> : IGraph<T> {

--- a/Sion.Useful/Classes/Graph.cs
+++ b/Sion.Useful/Classes/Graph.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Classes {
 	public class Graph<T> : IGraph<T> {

--- a/Sion.Useful/Classes/Node.cs
+++ b/Sion.Useful/Classes/Node.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Sion.Useful.Classes {
 	public class Node<T> {

--- a/Sion.Useful/Classes/WeightedDirectedGraph.cs
+++ b/Sion.Useful/Classes/WeightedDirectedGraph.cs
@@ -1,9 +1,6 @@
 ﻿using Sion.Useful.Interfaces;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Classes {
 	public class WeightedDirectedGraph<TValue, TWeight> : IWeightedGraph<TValue, TWeight> {

--- a/Sion.Useful/Classes/WeightedGraph.cs
+++ b/Sion.Useful/Classes/WeightedGraph.cs
@@ -1,9 +1,6 @@
 ﻿using Sion.Useful.Interfaces;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Classes {
 	public class WeightedGraph<TValue, TWeight> : IWeightedGraph<TValue, TWeight> {

--- a/Sion.Useful/Classes/WeightedNode.cs
+++ b/Sion.Useful/Classes/WeightedNode.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Sion.Useful.Classes {
 	public class WeightedNode<TValue, TWeight> {

--- a/Sion.Useful/DateTimeMethods.cs
+++ b/Sion.Useful/DateTimeMethods.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Sion.Useful.Methods {
+namespace Sion.Useful {
 	public static class DateTimeMethods {
 		public static long ConvertToUnixMilliseconds(DateTime date) {
 			DateTimeOffset offset = new(date);

--- a/Sion.Useful/DecimalMethods.cs
+++ b/Sion.Useful/DecimalMethods.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Sion.Useful.Methods {
+namespace Sion.Useful {
 	public static class DecimalMethods {
 		// Drops decimal points without rounding.
 		public static decimal Truncate(decimal d, int precision) {

--- a/Sion.Useful/Interfaces/IGraph.cs
+++ b/Sion.Useful/Interfaces/IGraph.cs
@@ -1,9 +1,5 @@
 ﻿using Sion.Useful.Classes;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Interfaces {
 	public interface IGraph<T> {

--- a/Sion.Useful/Interfaces/IWeightedGraph.cs
+++ b/Sion.Useful/Interfaces/IWeightedGraph.cs
@@ -1,9 +1,5 @@
 ﻿using Sion.Useful.Classes;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sion.Useful.Interfaces {
 	public interface IWeightedGraph<TValue, TWeight> {


### PR DESCRIPTION
… issues. All "method" classes will stay under the Sion.Useful namespace rather than Sion.Useful.Methods.